### PR TITLE
fix: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] Your bug report"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FR] Your feature request"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,6 @@ Fixes #\<issue\>
 
 ### Checklist
  - [ ] I filled out the body of this PR and removed the placeholder texts.
- - [ ] I used commit messages and named the title of this PR according to the [angular commit message format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).
+ - [ ] I used commit messages or named the title of this PR according to the [angular commit message format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).
 
 <!-- You can erase any parts of this template not applicable to your Pull Request. Please do not edit the checklist except ticking/unticking. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+### Description
+Quickly describe what you are solving and how.
+
+
+###  Related Issues
+Fixes #\<issue\>
+
+### Checklist
+ - [ ] I filled out the body of this PR and removed the placeholder texts.
+ - [ ] I used commit messages and named the title of this PR according to the [angular commit message format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).
+
+<!-- You can erase any parts of this template not applicable to your Pull Request. Please do not edit the checklist except ticking/unticking. -->


### PR DESCRIPTION
### Description
Add issue and pull request templates as there were none before.
This is not a fix but I wanted the release bot to create a new release when merging in dev later, so the dependencies get updated.

### Checklist
 - [X] I filled out the body of this PR and removed the placeholder texts.
 - [X] I used commit messages or named the title of this PR according to the [angular commit message format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).

<!-- You can erase any parts of this template not applicable to your Pull Request. Please do not edit the checklist except ticking/unticking. -->